### PR TITLE
bug: fix Uncaught ReferenceError: global is not defined

### DIFF
--- a/packages/nova-helpers/src/index.js
+++ b/packages/nova-helpers/src/index.js
@@ -3,7 +3,7 @@ import { fromScript } from 'hypernova';
 export const DATA_KEY = 'hypernova-key';
 export const DATA_ID = 'hypernova-id';
 
-const { document } = global;
+const { document } = globalThis;
 
 export const findNode = (name, id) => {
   const key = name.replace(/\W/g, '');


### PR DESCRIPTION
<img width="556" alt="image" src="https://user-images.githubusercontent.com/98843967/205299730-1389805c-310e-4c7d-b821-1b79af1ef88f.png">
  
  
Global is not accessible in browser environment with vite.
This will fix the issue with any system as globalThis will resolve with any system.